### PR TITLE
Use Docker's monorepo

### DIFF
--- a/docker_environment.go
+++ b/docker_environment.go
@@ -2,8 +2,8 @@ package circuit
 
 import (
 	"fmt"
-	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/operable/circuit-driver/api"
 	"github.com/operable/circuit-driver/io"
 	"golang.org/x/net/context"

--- a/environment.go
+++ b/environment.go
@@ -2,7 +2,7 @@ package circuit
 
 import (
 	"errors"
-	"github.com/docker/engine-api/client"
+	"github.com/docker/docker/client"
 	"github.com/operable/circuit-driver/api"
 )
 


### PR DESCRIPTION
This PR changes Docker package references away from the deprecated [docker/engine-api](https://github.com/docker/engine-api) repo to [docker/docker](https://github.com/docker/docker).